### PR TITLE
Amend PIDFile path in systemd service

### DIFF
--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -180,7 +180,7 @@ After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking
-PIDFile=/run/nginx.pid
+PIDFile=/var/run/nginx.pid
 ExecStartPre=/usr/sbin/nginx -t
 ExecStart=/usr/sbin/nginx
 ExecReload=/bin/kill -s HUP $MAINPID


### PR DESCRIPTION
The PID paths in the Nginx compile options and systemd service file don't match. 
Without this change, I was unable to stop the service using `sudo systemctl stop nginx` (no errors reported, but the processes were left running).