### PR TITLE
Add Dependency "dirmngr"

### DIFF
--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -42,6 +42,7 @@ mkdir $BPATH
 apt-get update && apt-get -y install \
   binutils \
   build-essential \
+  dirmngr \
   curl \
   libssl-dev
 


### PR DESCRIPTION
Debian 9.3 Stretch didn't have it installed by default and gave error about it when running this script.