### PR TITLE
Add Dependency "dirmngr"

### DIFF
--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -43,6 +43,7 @@ apt-get update && apt-get -y install \
   binutils \
   build-essential \
   curl \
+  dirmngr \
   libssl-dev
 
 # Download the source files


### PR DESCRIPTION
Debian 9.3 Stretch didn't have it installed by default and gave error about it when running this script.