### PR TITLE
Fixed the link to the license in the README to point to the right repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ The script was originally based on the [build_nginx.sh](https://gist.github.com/
 
 ## License
 
-Unless otherwise specified, all code is released under the MIT License (MIT). See the [repository's `LICENSE` file](https://github.com/MatthewVance/testssl-docker/blob/master/LICENSE) for details.
+Unless otherwise specified, all code is released under the MIT License (MIT). See the [repository's `LICENSE` file](https://github.com/MatthewVance/nginx-build/blob/master/LICENSE) for details.
 


### PR DESCRIPTION
It was pointing to a different repo, so I corrected it.