### PR TITLE
Use BPATH environment variable consistently.

### DIFF
--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -34,7 +34,7 @@ export BPATH=$(pwd)/build
 today=$(date +"%Y-%m-%d")
 
 # Clean out any files from previous runs of this script
-rm -rf build
+rm -rf $BPATH
 rm -rf /etc/nginx-default
 mkdir $BPATH
 
@@ -47,18 +47,18 @@ apt-get update && apt-get -y install \
   libssl-dev
 
 # Download the source files
-curl -L $SOURCE_PCRE$VERSION_PCRE.tar.gz -o ./build/PCRE.tar.gz && \
-  echo "${SHA256_PCRE} ./build/PCRE.tar.gz" | sha256sum -c -
-curl -L $SOURCE_ZLIB$VERSION_ZLIB.tar.gz -o ./build/ZLIB.tar.gz && \
-  echo "${SHA256_ZLIB} ./build/ZLIB.tar.gz" | sha256sum -c -
-curl -L $SOURCE_OPENSSL$VERSION_OPENSSL.tar.gz -o ./build/OPENSSL.tar.gz && \
-  echo "${SHA256_OPENSSL} ./build/OPENSSL.tar.gz" | sha256sum -c -
-curl -L $SOURCE_NGINX$VERSION_NGINX.tar.gz -o ./build/NGINX.tar.gz && \
-  echo "${SHA256_NGINX} ./build/NGINX.tar.gz" | sha256sum -c -
+curl -L $SOURCE_PCRE$VERSION_PCRE.tar.gz -o $BPATH/PCRE.tar.gz && \
+  echo "${SHA256_PCRE} ${BPATH}/PCRE.tar.gz" | sha256sum -c -
+curl -L $SOURCE_ZLIB$VERSION_ZLIB.tar.gz -o $BPATH/ZLIB.tar.gz && \
+  echo "${SHA256_ZLIB} ${BPATH}/ZLIB.tar.gz" | sha256sum -c -
+curl -L $SOURCE_OPENSSL$VERSION_OPENSSL.tar.gz -o $BPATH/OPENSSL.tar.gz && \
+  echo "${SHA256_OPENSSL} ${BPATH}/OPENSSL.tar.gz" | sha256sum -c -
+curl -L $SOURCE_NGINX$VERSION_NGINX.tar.gz -o $BPATH/NGINX.tar.gz && \
+  echo "${SHA256_NGINX} ${BPATH}/NGINX.tar.gz" | sha256sum -c -
 
 # Download the signature files
-curl -L $SOURCE_OPENSSL$VERSION_OPENSSL.tar.gz.asc -o ./build/OPENSSL.tar.gz.asc
-curl -L $SOURCE_NGINX$VERSION_NGINX.tar.gz.asc -o ./build/NGINX.tar.gz.asc
+curl -L $SOURCE_OPENSSL$VERSION_OPENSSL.tar.gz.asc -o $BPATH/OPENSSL.tar.gz.asc
+curl -L $SOURCE_NGINX$VERSION_NGINX.tar.gz.asc -o $BPATH/NGINX.tar.gz.asc
 
 # Verify GPG signature of downloads
 cd $BPATH


### PR DESCRIPTION
The BPATH variable specifies the working directory in which the build process takes place. However, it isn't used everywhere, there are still some hardcoded references. This pull request updates those hardcoded references.