### PR TITLE
Added support for TLS 1.3 (RFC8446)

### DIFF
--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -8,13 +8,13 @@ set -e -x
 # Set names of latest versions of each package
 export VERSION_PCRE=pcre-8.42
 export VERSION_ZLIB=zlib-1.2.11
-export VERSION_OPENSSL=openssl-1.1.0i
+export VERSION_OPENSSL=openssl-1.1.1-pre9
 export VERSION_NGINX=nginx-1.15.2
 
 # Set checksums of latest versions
 export SHA256_PCRE=69acbc2fbdefb955d42a4c606dfde800c2885711d2979e356c0636efde9ec3b5
 export SHA256_ZLIB=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-export SHA256_OPENSSL=ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99
+export SHA256_OPENSSL=95ebdfbb05e8451fb01a186ccaa4a7da0eff9a48999ede9fe1a7d90db75ccb4c
 export SHA256_NGINX=eeba09aecfbe8277ac33a5a2486ec2d6731739f3c1c701b42a0c3784af67ad90
 
 # Set OpenPGP keys used to sign downloads

--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -12,13 +12,13 @@ set -e -x
 # Set names of latest versions of each package
 version_pcre=pcre-8.42
 version_zlib=zlib-1.2.11
-version_openssl=openssl-1.1.1-pre9
+version_openssl=openssl-1.1.1
 version_nginx=nginx-1.15.3
 
 # Set checksums of latest versions
 sha256_pcre=69acbc2fbdefb955d42a4c606dfde800c2885711d2979e356c0636efde9ec3b5
 sha256_zlib=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-sha256_openssl=95ebdfbb05e8451fb01a186ccaa4a7da0eff9a48999ede9fe1a7d90db75ccb4c
+sha256_openssl=2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d
 sha256_nginx=9391fb91c3e2ebd040a4e3ac2b2f0893deb6232edc30a8e16fcc9c3fa9d6be85
 
 # Set OpenPGP keys used to sign downloads


### PR DESCRIPTION
This pull request is currently a work in progress, because it uses a development version of OpenSSL that isn't yet suitable for production use. Please do not merge until I have indicated to do so in the conversation below. I wanted to make this PR now to show others how they can get TLS 1.3 working in this script.

Edit: OpenSSL have released their final version of OpenSSL 1.1.1: [newslog](https://www.openssl.org/news/newslog.html), [blogpost](https://www.openssl.org/blog/blog/2018/09/11/release111/). This pull request may now be merged.