### PR TITLE
Updated regular expression for retrieving latest stable OpenSSL version

### DIFF
--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -21,7 +21,7 @@ source_nginx=https://nginx.org/download/
 # Look up latest versions of each package
 version_pcre=$(curl -sL ${source_pcre} | grep -Eo 'pcre\-[0-9.]+[0-9]' | sort -V | tail -n 1)
 version_zlib=$(curl -sL ${source_zlib} | grep -Eo 'zlib\-[0-9.]+[0-9]' | sort -V | tail -n 1)
-version_openssl=$(curl -sL ${source_openssl} | grep -Eo 'openssl\-[0-9]+\.[0-9]+\.[0-9]+[a-z]?(?=\.tar\.gz)' | sort -V | tail -n 1)
+version_openssl=$(curl -sL ${source_openssl} | grep -Po 'openssl\-[0-9]+\.[0-9]+\.[0-9]+[a-z]?(?=\.tar\.gz)' | sort -V | tail -n 1)
 version_nginx=$(curl -sL ${source_nginx} | grep -Eo 'nginx\-[0-9.]+[13579]\.[0-9]+' | sort -V | tail -n 1)
 
 # Set OpenPGP keys used to sign downloads

--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -21,7 +21,7 @@ source_nginx=https://nginx.org/download/
 # Look up latest versions of each package
 version_pcre=$(curl -sL ${source_pcre} | grep -Eo 'pcre\-[0-9.]+[0-9]' | sort -V | tail -n 1)
 version_zlib=$(curl -sL ${source_zlib} | grep -Eo 'zlib\-[0-9.]+[0-9]' | sort -V | tail -n 1)
-version_openssl=$(curl -sL ${source_openssl} | grep -Eo 'openssl\-[0-9.]+[a-z]?' | sort -V | tail -n 1)
+version_openssl=$(curl -sL ${source_openssl} | grep -Eo 'openssl\-[0-9]+\.[0-9]+\.[0-9]+[a-z]?(?=\.tar\.gz)' | sort -V | tail -n 1)
 version_nginx=$(curl -sL ${source_nginx} | grep -Eo 'nginx\-[0-9.]+[13579]\.[0-9]+' | sort -V | tail -n 1)
 
 # Set OpenPGP keys used to sign downloads


### PR DESCRIPTION
Updated regular expression for retrieving latest stable OpenSSL version using positive lookahead. Fixes #84.

Matches:
openssl-3.0.0.tar.gz (future release)
openssl-1.1.1g.tar.gz (newest stable release that should be used)
openssl-1.1.1.tar.gz (older stable release)

Does not match:
openssl-3.0.0-alpha1.tar.gz (not a stable release)
openssl-1.1.1.1g.tar.gz (invalid version scheme)
openssl-1.1.1.g.tar.gz (invalid version scheme)
openssl-1.1.1-pre1.tar.gz (not a stable release)
openssl-fips-2.0.16.tar.gz (wrong feature set)
openssl-fips-ecp-2.0.16.tar.gz (wrong feature set)