### PR TITLE
Added PGP keys for different OpenSSL members

### DIFF
--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -27,7 +27,10 @@ version_nginx=$(curl -sL ${source_nginx} | grep -Eo 'nginx\-[0-9.]+[13579]\.[0-9
 # Set OpenPGP keys used to sign downloads
 opgp_pcre=45F68D54BBE23FB3039B46E59766E084FB0F43D8
 opgp_zlib=5ED46A6721D365587791E2AA783FCD8E58BCAFBA
-opgp_openssl=7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C
+opgp_openssl_1=8657ABB260F056B1E5190839D9C4D26D0E604491 #Matt Caswell
+opgp_openssl_2=B7C1C14360F353A36862E4D5231C84CDDCC69C45 #Paul Dale
+opgp_openssl_3=7953AC1FBC3DC8B3B292393ED5E9E43F7DF9EE8C #Richaard Levitte
+opgp_openssl_4=A21FAB74B0088AA361152586B8EF1A6BA9DA2D5C #Tomas Mrax
 opgp_nginx=13C82A63B603576156E30A4EA0EA981B66B0D967
 
 # Set where OpenSSL and NGINX will be built
@@ -66,7 +69,7 @@ curl -L "${source_nginx}${version_nginx}.tar.gz.asc" -o "${bpath}/nginx.tar.gz.a
 cd "$bpath"
 GNUPGHOME="$(mktemp -d)"
 export GNUPGHOME
-gpg --keyserver keyserver.ubuntu.com --recv-keys "$opgp_pcre" "$opgp_zlib" "$opgp_openssl" "$opgp_nginx"
+gpg --keyserver keyserver.ubuntu.com --recv-keys "$opgp_pcre" "$opgp_zlib" "$opgp_openssl_1" "$opgp_openssl_2" "$opgp_openssl_3" "$opgp_openssl_4" "$opgp_nginx"
 gpg --batch --verify pcre.tar.gz.sig pcre.tar.gz
 gpg --batch --verify zlib.tar.gz.asc zlib.tar.gz
 gpg --batch --verify openssl.tar.gz.asc openssl.tar.gz


### PR DESCRIPTION
As stated on OpenSSL official sources download page (https://www.openssl.org/source/) "PGP keys for the signatures are available from the OTC page. Current members that sign releases include Richard Levitte, Matt Caswell, Paul Dale, and Tomas Mraz."

Added the summentioned keys from https://www.openssl.org/community/otc.html